### PR TITLE
Refine OR null masking for search function

### DIFF
--- a/be/src/vec/functions/function_search.h
+++ b/be/src/vec/functions/function_search.h
@@ -171,6 +171,12 @@ public:
     bool should_mask_null_values(const TSearchClause& clause) const;
 
 private:
+    Status collect_query_null_bitmap_internal(
+            const TSearchClause& clause,
+            const std::unordered_map<std::string, IndexIterator*>& iterators,
+            std::shared_ptr<roaring::Roaring>& null_bitmap, bool collect_nulls) const;
+
+    bool is_or_clause_null_safe(const TSearchClause& clause) const;
 };
 
 } // namespace doris::vectorized


### PR DESCRIPTION
## Summary
- analyze OR clauses to detect NOT operators and shared fields so we only skip NULL masking when every branch is independent
- adjust NULL bitmap collection to avoid unnecessary unions when masking is not required while preserving the existing behavior otherwise
- extend `function_search_test` with scenarios that compare `search` against `match_any`/`match_all` row sets for OR across fields and OR with NOT on the same field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da65558fe483268789ba22921fd836

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Analyze OR clauses for null-safety to decide when to mask/collect NULLs, and add targeted tests to validate behavior.
> 
> - **Search null handling**:
>   - Add `analyze_null_safety` to detect `NOT` and cross-field overlaps; introduce `is_or_clause_null_safe`.
>   - Update `should_mask_null_values` to mask only unsafe `OR` trees; preserve masking for others.
>   - Refactor NULL bitmap collection via `collect_query_null_bitmap_internal(..., collect_nulls)` to avoid reading/unioning NULL bitmaps when not needed; handle `has_null()` as `Result<bool>`.
> - **API/Headers**:
>   - Add helpers and declarations in `function_search.h`; include `<unordered_set>`/`<vector>`.
> - **Tests**:
>   - Add `TrackingIndexIterator` and new cases:
>     - OR across different fields: no NULL masking/collection.
>     - OR with NOT on same field: apply NULL masking and collect NULLs.
>   - Extend assertions for has-null checks and bitmap effects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67aa9bdf10432b9286f205557fc97ac99efa00b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->